### PR TITLE
Fix hardcoded timeout values in IntercomClient (Issue #1)

### DIFF
--- a/fast_intercom_mcp/cli.py
+++ b/fast_intercom_mcp/cli.py
@@ -110,7 +110,7 @@ def init(ctx, token, sync_days):
     
     # Test connection
     async def test_connection():
-        client = IntercomClient(token)
+        client = IntercomClient(token, config.api_timeout_seconds)
         if await client.test_connection():
             click.echo("✅ Connection to Intercom API successful")
             app_id = await client.get_app_id()
@@ -134,7 +134,7 @@ def init(ctx, token, sync_days):
         click.echo("🔄 Starting initial sync (this may take a few minutes)...")
         
         async def initial_sync():
-            client = IntercomClient(token)
+            client = IntercomClient(token, config.api_timeout_seconds)
             sync_manager = SyncManager(db, client)
             sync_service = sync_manager.get_sync_service()
             
@@ -183,7 +183,7 @@ def start(ctx, daemon, port, host, api_key):
     
     # Initialize components
     db = DatabaseManager(config.database_path)
-    intercom_client = IntercomClient(config.intercom_token)
+    intercom_client = IntercomClient(config.intercom_token, config.api_timeout_seconds)
     sync_manager = SyncManager(db, intercom_client)
     
     # Create appropriate server based on transport mode
@@ -277,7 +277,7 @@ def serve(ctx, port, host, api_key):
     
     # Initialize components
     db = DatabaseManager(config.database_path)
-    intercom_client = IntercomClient(config.intercom_token)
+    intercom_client = IntercomClient(config.intercom_token, config.api_timeout_seconds)
     sync_manager = SyncManager(db, intercom_client)
     
     server = FastIntercomHTTPServer(
@@ -345,7 +345,7 @@ def mcp(ctx):
     
     # Initialize components
     db = DatabaseManager(config.database_path)
-    intercom_client = IntercomClient(config.intercom_token)
+    intercom_client = IntercomClient(config.intercom_token, config.api_timeout_seconds)
     sync_manager = SyncManager(db, intercom_client)
     mcp_server = FastIntercomMCPServer(db, sync_manager.get_sync_service(), intercom_client)
     
@@ -423,7 +423,7 @@ def sync(ctx, force, days):
     
     async def run_sync():
         db = DatabaseManager(config.database_path)
-        intercom_client = IntercomClient(config.intercom_token)
+        intercom_client = IntercomClient(config.intercom_token, config.api_timeout_seconds)
         sync_manager = SyncManager(db, intercom_client)
         sync_service = sync_manager.get_sync_service()
         

--- a/fast_intercom_mcp/config.py
+++ b/fast_intercom_mcp/config.py
@@ -17,6 +17,7 @@ class Config:
     max_sync_age_minutes: int = 5
     background_sync_interval_minutes: int = 10
     initial_sync_days: int = 30  # 0 means ALL history
+    api_timeout_seconds: int = 300
     
     @classmethod
     def load(cls, config_path: Optional[str] = None) -> 'Config':
@@ -42,11 +43,12 @@ class Config:
             'max_sync_age_minutes': os.getenv('FASTINTERCOM_MAX_SYNC_AGE_MINUTES'),
             'background_sync_interval_minutes': os.getenv('FASTINTERCOM_BACKGROUND_SYNC_INTERVAL'),
             'initial_sync_days': os.getenv('FASTINTERCOM_INITIAL_SYNC_DAYS'),
+            'api_timeout_seconds': os.getenv('FASTINTERCOM_API_TIMEOUT_SECONDS'),
         }
         
         for key, value in env_overrides.items():
             if value is not None:
-                if key in ['max_sync_age_minutes', 'background_sync_interval_minutes', 'initial_sync_days']:
+                if key in ['max_sync_age_minutes', 'background_sync_interval_minutes', 'initial_sync_days', 'api_timeout_seconds']:
                     config_data[key] = int(value)
                 else:
                     config_data[key] = value

--- a/fast_intercom_mcp/intercom_client.py
+++ b/fast_intercom_mcp/intercom_client.py
@@ -17,8 +17,9 @@ logger = logging.getLogger(__name__)
 class IntercomClient:
     """Intercom API client with smart sync and rate limiting."""
     
-    def __init__(self, access_token: str):
+    def __init__(self, access_token: str, timeout: int = 300):
         self.access_token = access_token
+        self.timeout = timeout
         self.base_url = "https://api.intercom.io"
         self.headers = {
             "Authorization": f"Bearer {access_token}",
@@ -38,7 +39,7 @@ class IntercomClient:
             return self._app_id
             
         try:
-            async with httpx.AsyncClient(timeout=10.0) as client:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
                 response = await client.get(f"{self.base_url}/me", headers=self.headers)
                 if response.status_code == 200:
                     data = response.json()
@@ -88,7 +89,7 @@ class IntercomClient:
         conversations = []
         api_calls = 0
         
-        async with httpx.AsyncClient(timeout=30.0) as client:
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
             # Build search filters
             search_filters = [
                 {
@@ -194,7 +195,7 @@ class IntercomClient:
         """
         conversations = []
         
-        async with httpx.AsyncClient(timeout=30.0) as client:
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
             # Use updated_at to capture both new conversations AND existing conversations with new messages
             search_filters = [
                 {
@@ -347,7 +348,7 @@ class IntercomClient:
     async def test_connection(self) -> bool:
         """Test if the API connection is working."""
         try:
-            async with httpx.AsyncClient(timeout=10.0) as client:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
                 response = await client.get(f"{self.base_url}/me", headers=self.headers)
                 return response.status_code == 200
         except Exception as e:


### PR DESCRIPTION
## Summary
- Replaces all hardcoded timeout values with configurable timeout setting
- Adds `api_timeout_seconds` configuration option with 300s default  
- Updates IntercomClient constructor to accept timeout parameter
- Ensures all HTTP requests respect the configured timeout value

## Changes Made
- **Config**: Added `api_timeout_seconds` field with default 300s timeout
- **IntercomClient**: Updated constructor to accept timeout parameter, replaced hardcoded timeouts
- **CLI**: Updated all IntercomClient instantiations to use `config.api_timeout_seconds`

## Quality Control Verification
- ✅ No hardcoded timeout values (300.0 or 30) remain in intercom_client.py
- ✅ All `httpx.AsyncClient(timeout=...)` calls use `self.timeout`  
- ✅ CLI uses `config.api_timeout_seconds` instead of hardcoded values
- ✅ IntercomClient constructor default matches config default (300s)

## Test Plan
- [x] Python syntax validation passes for all modified files
- [x] All hardcoded timeout values successfully replaced
- [x] Configuration properly loads timeout setting from environment/file
- [x] IntercomClient respects timeout parameter in all HTTP calls

Fixes #1