### PR TITLE
Fix #48: Integration test and IntercomClient bugs

### DIFF
--- a/fast_intercom_mcp/cli.py
+++ b/fast_intercom_mcp/cli.py
@@ -113,7 +113,7 @@ def init(_ctx, token, sync_days):
 
     # Test connection
     async def test_connection():
-        client = IntercomClient(token, config.api_timeout_seconds)
+        client = IntercomClient(token, timeout=config.api_timeout_seconds)
         if await client.test_connection():
             click.echo("✅ Connection to Intercom API successful")
             app_id = await client.get_app_id()
@@ -136,7 +136,7 @@ def init(_ctx, token, sync_days):
         click.echo("🔄 Starting initial sync (this may take a few minutes)...")
 
         async def initial_sync():
-            client = IntercomClient(token, config.api_timeout_seconds)
+            client = IntercomClient(token, timeout=config.api_timeout_seconds)
             sync_manager = SyncManager(db, client)
             sync_service = sync_manager.get_sync_service()
 

--- a/fast_intercom_mcp/config.py
+++ b/fast_intercom_mcp/config.py
@@ -95,11 +95,17 @@ class Config:
     @staticmethod
     def get_default_config_path() -> str:
         """Get the default configuration file path."""
+        config_dir = os.getenv("FASTINTERCOM_CONFIG_DIR")
+        if config_dir:
+            return str(Path(config_dir) / "config.json")
         return str(Path.home() / ".fastintercom" / "config.json")
 
     @staticmethod
     def get_default_data_dir() -> str:
         """Get the default data directory."""
+        config_dir = os.getenv("FASTINTERCOM_CONFIG_DIR")
+        if config_dir:
+            return str(Path(config_dir))
         return str(Path.home() / ".fastintercom")
 
 

--- a/fast_intercom_mcp/database.py
+++ b/fast_intercom_mcp/database.py
@@ -28,9 +28,13 @@ class DatabaseManager:
 
         self.pool_size = pool_size
         if db_path is None:
-            # Default to user's home directory
-            home_dir = Path.home()
-            self.db_dir = home_dir / ".fastintercom"
+            # Default to config directory if set, otherwise user's home directory
+            config_dir = os.getenv("FASTINTERCOM_CONFIG_DIR")
+            if config_dir:
+                self.db_dir = Path(config_dir)
+            else:
+                home_dir = Path.home()
+                self.db_dir = home_dir / ".fastintercom"
             self.db_dir.mkdir(exist_ok=True)
             self.db_path = self.db_dir / "data.db"
         else:

--- a/fast_intercom_mcp/transport/optimization.py
+++ b/fast_intercom_mcp/transport/optimization.py
@@ -355,6 +355,7 @@ class APIOptimizer:
         cache_key: str = None,
         cache_ttl: int = None,
         priority: str = "normal",
+        timeout: float = None,
     ) -> Any:
         """Make an optimized API request with caching, deduplication, etc.
 
@@ -405,6 +406,9 @@ class APIOptimizer:
                     request_kwargs["json"] = data
                 else:
                     request_kwargs["params"] = data
+            
+            if timeout is not None:
+                request_kwargs["timeout"] = timeout
 
             response = await client.request(**request_kwargs)
             response.raise_for_status()


### PR DESCRIPTION
## Summary
This PR fixes multiple bugs that prevented the integration test from running with real Intercom data.

## Changes
1. **Fixed integration test script**:
   - Changed `fast-intercom-mcp init --force` to `--token` (correct syntax)
   - Added support for loading `INTERCOM_ACCESS_TOKEN` from .env file
   - Handle interactive prompt by piping "n" to skip initial sync
   - Added verbose output capture for debugging

2. **Fixed IntercomClient parameter passing**:
   - Added `timeout` parameter to `APIOptimizer.make_request()`
   - Fixed CLI to pass timeout as named parameter
   - Ensures compatibility between components

3. **Added FASTINTERCOM_CONFIG_DIR support**:
   - Config class now respects the environment variable
   - DatabaseManager uses config dir when no path specified
   - Allows tests to run in isolated workspaces

## Test Results
- ✅ API connection works with real token ("Spritz Resolution Team" workspace)
- ✅ Config and database files created in correct test workspace
- ✅ All components respect FASTINTERCOM_CONFIG_DIR
- ✅ Integration test can now run with real Intercom data

## Related Issues
Closes #48

## Test Plan
- [x] Unit tests pass
- [x] Integration test runs successfully with real Intercom token
- [x] Config and database created in test workspace
- [x] No hardcoded tokens in committed files