### PR TITLE
Fix linting configuration consistency between local and CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.6
+    hooks:
+      - id: ruff
+        args: [--fix, --config, pyproject.toml]
+      - id: ruff-format
+        args: [--config, pyproject.toml]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,4 +1,0 @@
-[lint]
-select = ["E", "F"]
-ignore = ["E501"]  # Ignore line length for now
-exclude = ["venv", "__pycache__"]


### PR DESCRIPTION
## Summary
Fix the discrepancy between local and CI linting environments that was causing PRs to fail CI checks despite passing local linting.

## Problem
- Local development was using `.ruff.toml` which ignored E501 (line length) errors
- CI explicitly uses `pyproject.toml` which enforces 100-character line limits
- No `.pre-commit-config.yaml` existed, so pre-commit hooks weren't running ruff

## Solution
- Remove conflicting `.ruff.toml` file
- Create `.pre-commit-config.yaml` that explicitly uses `pyproject.toml`
- This ensures local and CI environments use the same linting configuration

## Impact
- Developers will now catch linting errors locally before pushing
- Pre-commit hooks will automatically run ruff with the correct configuration
- No more surprises with CI failures for linting issues

## Test Plan
- [x] Pre-commit hooks installed and working
- [x] Local ruff now uses pyproject.toml configuration
- [ ] CI checks should pass