### PR TITLE
Fix: Add missing get_conversation_by_id method

### DIFF
--- a/fast_intercom_mcp/sync/coordinator.py
+++ b/fast_intercom_mcp/sync/coordinator.py
@@ -384,9 +384,6 @@ class TwoPhaseSyncCoordinator:
             total_messages=total_messages,
             duration_seconds=total_duration,
             api_calls_made=total_api_calls,
-            sync_type="two_phase",
-            period_start=None,  # Set by caller if needed
-            period_end=None,  # Set by caller if needed
         )
 
     def get_operation_status(self) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
Fixes unit test failure discovered during pre-release testing. The two-phase sync coordinator expected a database method that was removed during the sync architecture simplification.

## Changes
- Added `get_conversation_by_id` method to DatabaseManager
- Made it compatible with both test and production database schemas
- Fixed SyncStats initialization in coordinator (removed non-existent fields)

## Test Plan
- [x] Unit tests pass locally
- [x] Specific failing test now passes
- [x] All 86 tests pass without issues

## Context
This was discovered during v0.4.0 pre-release testing and is part of the technical debt from merging multiple PRs without comprehensive integration testing.