### PR TITLE
Fix #65: Update integration test API calls to match current signatures

### DIFF
--- a/tests/integration/test_e2e_comprehensive.py
+++ b/tests/integration/test_e2e_comprehensive.py
@@ -124,7 +124,7 @@ class IntegrationTestRunner:
             return False
 
         token = os.getenv("INTERCOM_ACCESS_TOKEN")
-        self.intercom_client = IntercomClient(token, timeout_seconds=30)
+        self.intercom_client = IntercomClient(token, timeout=30)
 
         try:
             # Test basic connection
@@ -158,7 +158,7 @@ class IntegrationTestRunner:
             return False
 
         try:
-            self.db = DatabaseManager(self.db_path, connection_pool_size=5)
+            self.db = DatabaseManager(self.db_path, pool_size=5)
 
             # Check if database was created and initialized
             if not os.path.exists(self.db_path):


### PR DESCRIPTION
## Summary
- Fixed IntercomClient API call to use correct `timeout` parameter instead of `timeout_seconds`
- Fixed DatabaseManager API call to use correct `pool_size` parameter instead of `connection_pool_size`
- Verified test compiles and runs properly (skips when INTERCOM_ACCESS_TOKEN not set)

## Related Issues
Closes #65

## Test Plan
- [x] Test file compiles without syntax errors
- [x] Ruff linting passes
- [x] Test properly skips when INTERCOM_ACCESS_TOKEN is not set
- [x] Module imports work correctly

## Changes Made
1. Changed `IntercomClient(token, timeout_seconds=30)` to `IntercomClient(token, timeout=30)`
2. Changed `DatabaseManager(self.db_path, connection_pool_size=5)` to `DatabaseManager(self.db_path, pool_size=5)`

These changes ensure the integration test matches the current API signatures and can run when the proper environment is configured.