### PR TITLE
Fix linting: Break long line in test_mcp_server.py

### DIFF
--- a/scripts/test_mcp_server.py
+++ b/scripts/test_mcp_server.py
@@ -581,9 +581,10 @@ class MCPServerTester:
             print(f"\n{Colors.RED}Failed Tests:{Colors.NC}")
             for result in self.results:
                 if result.get("status") in ["FAILED", "ERROR"]:
-                    print(
-                        f"  - {result['tool']}: {result.get('error', result.get('validation_errors', 'Unknown error'))}"
+                    error_msg = result.get(
+                        "error", result.get("validation_errors", "Unknown error")
                     )
+                    print(f"  - {result['tool']}: {error_msg}")
 
         # Log summary for automated parsing
         logger.info(


### PR DESCRIPTION
## Summary
Fixes failing fast-check CI by breaking a line that exceeded the 100 character limit.

## Issue
The fast-check workflow was failing with:
```
scripts/test_mcp_server.py:585:121: E501 Line too long (120 > 100)
```

## Fix
- Split line 585 into multiple lines
- Extract error message to separate variable for better readability
- Maintains same functionality while complying with linting rules